### PR TITLE
Add CODE_DATA_METADATA option of code block

### DIFF
--- a/ext/qiita_marker/html.c
+++ b/ext/qiita_marker/html.c
@@ -10,6 +10,7 @@
 #include "syntax_extension.h"
 #include "html.h"
 #include "render.h"
+#include "qfm.h"
 
 // Functions to convert cmark_nodes to HTML strings.
 
@@ -222,6 +223,18 @@ static int S_render_node(cmark_html_renderer *renderer, cmark_node *node,
           escape_html(html, node->as.code.info.data + first_tag + 1, node->as.code.info.len - first_tag - 1);
         }
         cmark_strbuf_puts(html, "\"><code>");
+      } else if (options & CMARK_OPT_CODE_DATA_METADATA) {
+        cmark_strbuf_puts(html, "<pre");
+        cmark_html_render_sourcepos(node, html, options);
+        cmark_strbuf_puts(html, "><code data-metadata=\"");
+        escape_html(html, node->as.code.info.data, first_tag);
+        if (first_tag < node->as.code.info.len &&
+            (options & CMARK_OPT_FULL_INFO_STRING)) {
+          cmark_strbuf_puts(html, "\" data-meta=\"");
+          escape_html(html, node->as.code.info.data + first_tag + 1,
+                      node->as.code.info.len - first_tag - 1);
+        }
+        cmark_strbuf_puts(html, "\">");
       } else {
         cmark_strbuf_puts(html, "<pre");
         cmark_html_render_sourcepos(node, html, options);

--- a/ext/qiita_marker/qfm.h
+++ b/ext/qiita_marker/qfm.h
@@ -1,0 +1,16 @@
+#ifndef QFM_H
+#define QFM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Use <pre><code data-metadata="x"> tags for code blocks instead of <pre><code
+ * class="language-x">. **/
+#define CMARK_OPT_CODE_DATA_METADATA (1 << 25)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/qiita_marker/config.rb
+++ b/lib/qiita_marker/config.rb
@@ -28,7 +28,8 @@ module QiitaMarker
         FOOTNOTES: (1 << 13),
         STRIKETHROUGH_DOUBLE_TILDE: (1 << 14),
         TABLE_PREFER_STYLE_ATTRIBUTES: (1 << 15),
-        FULL_INFO_STRING: (1 << 16)
+        FULL_INFO_STRING: (1 << 16),
+        CODE_DATA_METADATA: (1 << 25)
       }.freeze,
       format: %i[html xml commonmark plaintext].freeze
     }.freeze

--- a/lib/qiita_marker/renderer/html_renderer.rb
+++ b/lib/qiita_marker/renderer/html_renderer.rb
@@ -94,6 +94,10 @@ module QiitaMarker
           out("<pre#{sourcepos(node)}")
           out(' lang="', node.fence_info.split(/\s+/)[0], '"') if node.fence_info && !node.fence_info.empty?
           out('><code>')
+        elsif option_enabled?(:CODE_DATA_METADATA)
+          out("<pre#{sourcepos(node)}><code")
+          out(' data-metadata="', node.fence_info.split(/\s+/)[0], '"') if node.fence_info && !node.fence_info.empty?
+          out('>')
         else
           out("<pre#{sourcepos(node)}><code")
           if node.fence_info && !node.fence_info.empty?

--- a/tasks/qiita_marker.rake
+++ b/tasks/qiita_marker.rake
@@ -13,6 +13,12 @@ namespace :qiita_marker do
     sh 'rm -fr ext/qiita_marker/cmark-upstream'
     sh 'git mv ext/commonmarker/cmark-upstream ext/qiita_marker/cmark-upstream'
   end
+
+  desc 'Format clang files of qfm'
+  task :format_qfm do
+    paths = Dir.glob('ext/qiita_marker/qfm*.{c,h,re}')
+    sh "clang-format -style llvm -i #{paths.join(' ')}"
+  end
 end
 
 module ProjectRenamer

--- a/test/test_qfm_code_data_metadata.rb
+++ b/test/test_qfm_code_data_metadata.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require('test_helper')
+
+class TestQfmCodeDataMetadata < Minitest::Test
+  def setup
+    text = <<~MD
+      ```ruby:example.rb
+      puts :foo
+      ```
+    MD
+    @doc = QiitaMarker.render_doc(text, :DEFAULT, [])
+    @expected = <<~HTML
+      <pre><code data-metadata="ruby:example.rb">puts :foo
+      </code></pre>
+    HTML
+  end
+
+  def test_to_html
+    assert_equal(@expected, @doc.to_html(:CODE_DATA_METADATA))
+  end
+
+  def test_html_renderer
+    assert_equal(@expected, QiitaMarker::HtmlRenderer.new(options: :CODE_DATA_METADATA).render(@doc))
+  end
+end


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the MIT License.
-->

## What

Add `CODE_DATA_METADATA` option of code block.

By enabling the option, code block can be rendered as follows.

    ```ruby:example.rb
    puts :foo
    ```

```ruby
QiitaMarker.render_html(md, :CODE_DATA_METADATA)
# => "<pre><code data-metadata="ruby:example.rb">puts :foo\n</code></pre>"
```
