### PR TITLE
Add `MENTION_NO_EMPHASIS` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - [#9](https://github.com/increments/qiita_marker/pull/9): Add new `CODE_DATA_METADATA` option.
+- [#11](https://github.com/increments/qiita_marker/pull/11) Add `MENTION_NO_EMPHASIS` option.
 
 ### Changed
 

--- a/ext/qiita_marker/qfm.h
+++ b/ext/qiita_marker/qfm.h
@@ -9,6 +9,9 @@ extern "C" {
  * class="language-x">. **/
 #define CMARK_OPT_CODE_DATA_METADATA (1 << 25)
 
+/* Prevent parsing Qiita-style Mentions as emphasis. */
+#define CMARK_OPT_MENTION_NO_EMPHASIS (1 << 26)
+
 #ifdef __cplusplus
 }
 #endif

--- a/ext/qiita_marker/qfm_mention_no_emphasis.c
+++ b/ext/qiita_marker/qfm_mention_no_emphasis.c
@@ -1,0 +1,37 @@
+#include "cmark_ctype.h"
+#include "cmark-gfm.h"
+#include "config.h"
+
+static bool is_wordchar(char c) {
+  return cmark_isalnum(c) || c == '_' || c == '-';
+}
+
+bool is_part_of_mention(unsigned char *data, bufsize_t offset) {
+  int i;
+  int lookbehind_limit = (int)-offset;
+  char character;
+
+  for (i = 0; i >= lookbehind_limit; i--) {
+    character = data[i];
+
+    if (is_wordchar(character)) {
+      // Continue lookbehind.
+    } else if (character == '@') {
+      if (i == offset) {
+        // The "@" is at beginning of the text. (e.g. "@foo")
+        return true;
+      } else {
+        // Check if the previous character of the "@" is alphanumeric or not.
+        //   " @foo" and "あ@foo" are mentions.
+        //   "a@foo" is not a mention.
+        char prev_character = data[i - 1];
+        return !cmark_isalnum(prev_character);
+      }
+    } else {
+      // Found non-mention character, so this is not a mention.
+      return false;
+    }
+  }
+
+  return false;
+}

--- a/ext/qiita_marker/qfm_mention_no_emphasis.h
+++ b/ext/qiita_marker/qfm_mention_no_emphasis.h
@@ -1,0 +1,8 @@
+#ifndef QFM_MENTION_NO_EMPHASIS
+#define QFM_MENTION_NO_EMPHASIS
+
+#include "cmark-gfm.h"
+
+bool is_part_of_mention(unsigned char *data, bufsize_t offset);
+
+#endif

--- a/lib/qiita_marker/config.rb
+++ b/lib/qiita_marker/config.rb
@@ -29,7 +29,8 @@ module QiitaMarker
         STRIKETHROUGH_DOUBLE_TILDE: (1 << 14),
         TABLE_PREFER_STYLE_ATTRIBUTES: (1 << 15),
         FULL_INFO_STRING: (1 << 16),
-        CODE_DATA_METADATA: (1 << 25)
+        CODE_DATA_METADATA: (1 << 25),
+        MENTION_NO_EMPHASIS: (1 << 26)
       }.freeze,
       format: %i[html xml commonmark plaintext].freeze
     }.freeze

--- a/test/test_qfm_mention_no_emphasis.rb
+++ b/test/test_qfm_mention_no_emphasis.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestQfmMentionNoEmphasis < Minitest::Test
+  describe 'with mention_no_emphasis option' do
+    [
+      ['@_username_',         false],
+      ['@__username__',       false],
+      ['@___username___',     false],
+      ['@user__name__',       false],
+      ['@some__user__name__', false],
+      [' @_username_',        false],
+      ['あ@_username_', false],
+      ['A@_username_',        true],
+      ['@*username*',         true],
+      ['_foo_',               true],
+      ['_',                   false],
+      ['_foo @username_',     false],
+      ['__foo @username__',   false],
+      ['___foo @username___', false]
+    ].each do |text, emphasize|
+      describe "with text #{text.inspect}" do
+        if emphasize
+          it 'emphasizes the text' do
+            QiitaMarker.render_html(text, :MENTION_NO_EMPHASIS).tap do |out|
+              assert_match(/(<em>|<strong>)/, out.chomp)
+            end
+          end
+        else
+          it 'does not emphasize the text' do
+            QiitaMarker.render_html(text, :MENTION_NO_EMPHASIS).tap do |out|
+              assert_match "<p>#{text.strip}</p>", out.chomp
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe 'without mention_no_emphasis option' do
+    describe 'with text "@_username_"' do
+      text = '@_username_'
+      it 'emphasizes the text' do
+        QiitaMarker.render_html(text, :DEFAULT, %i[]).tap do |out|
+          assert_match(/<em>/, out.chomp)
+        end
+      end
+    end
+
+    describe 'with text "_foo @username_"' do
+      text = '_foo @username_'
+      it 'emphasizes the text' do
+        QiitaMarker.render_html(text, :DEFAULT, %i[]).tap do |out|
+          assert_match(/<em>/, out.chomp)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the MIT License.
-->
## What

- Add `MENTION_NO_EMPHASIS` option
    - To prevent parsing Qiita-style Mentions as emphasis

 When this option is enabled, username including underscores like `@_username_` will not be parsed as emphasis like `@<em>username</em>`