### PR TITLE
Add AUTOLINK_CLASS_NAME option for autolink extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- [#21](https://github.com/increments/qiita_marker/pull/21): Add `AUTOLINK_CLASS_NAME` option for autolink extension.
+
 ### Changed
 
 - [#19](https://github.com/increments/qiita_marker/pull/19): Allow a custom block to contain any node type.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ In addition to CommonMarker's options and extensions, the following are availabl
 | Name | Description |
 | --- | --- |
 | `:MENTION_NO_EMPHASIS` | Prevent parsing mentions as emphasis. |
+| `:AUTOLINK_CLASS_NAME` | Append `class="autolink"` to extension's autolinks. |
 
 #### Render options
 
@@ -27,6 +28,7 @@ In addition to CommonMarker's options and extensions, the following are availabl
 | --- | --- |
 | `:CODE_DATA_METADATA` | Use `<code data-metadata>` for fenced code blocks. |
 | `:MENTION_NO_EMPHASIS` | Prevent parsing mentions as emphasis. |
+| `:AUTOLINK_CLASS_NAME` | Append `class="autolink"` to extension's autolinks. |
 
 ### Original extensions
 

--- a/ext/qiita_marker/qfm.h
+++ b/ext/qiita_marker/qfm.h
@@ -12,6 +12,9 @@ extern "C" {
 /* Prevent parsing Qiita-style Mentions as emphasis. */
 #define CMARK_OPT_MENTION_NO_EMPHASIS (1 << 26)
 
+/* Render autolinks with class name  */
+#define CMARK_OPT_AUTOLINK_CLASS_NAME (1 << 27)
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/qiita_marker/config.rb
+++ b/lib/qiita_marker/config.rb
@@ -14,7 +14,8 @@ module QiitaMarker
         LIBERAL_HTML_TAG: (1 << 12),
         FOOTNOTES: (1 << 13),
         STRIKETHROUGH_DOUBLE_TILDE: (1 << 14),
-        MENTION_NO_EMPHASIS: (1 << 26)
+        MENTION_NO_EMPHASIS: (1 << 26),
+        AUTOLINK_CLASS_NAME: (1 << 27)
       }.freeze,
       render: {
         DEFAULT: 0,
@@ -31,7 +32,8 @@ module QiitaMarker
         TABLE_PREFER_STYLE_ATTRIBUTES: (1 << 15),
         FULL_INFO_STRING: (1 << 16),
         CODE_DATA_METADATA: (1 << 25),
-        MENTION_NO_EMPHASIS: (1 << 26)
+        MENTION_NO_EMPHASIS: (1 << 26),
+        AUTOLINK_CLASS_NAME: (1 << 27)
       }.freeze,
       format: %i[html xml commonmark plaintext].freeze
     }.freeze

--- a/test/test_qfm_autolink_class_name.rb
+++ b/test/test_qfm_autolink_class_name.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require('test_helper')
+
+describe 'TestQfmAutolinkClassName' do
+  let(:options) { %i[AUTOLINK_CLASS_NAME] }
+  let(:extensions) { %i[autolink] }
+  let(:text) do
+    <<~MD
+      https://example.com
+      <https://example.com>
+      [Example](https://example.com)
+      test@example.com
+    MD
+  end
+  let(:doc) { QiitaMarker.render_doc(text, options, extensions) }
+  let(:expected) do
+    <<~HTML
+      <p><a href="https://example.com" class="autolink">https://example.com</a>
+      <a href="https://example.com">https://example.com</a>
+      <a href="https://example.com">Example</a>
+      <a href="mailto:test@example.com" class="autolink">test@example.com</a></p>
+    HTML
+  end
+  let(:rendered_html) { doc.to_html(options, extensions) }
+
+  it "appends class name to extension's autolinks" do
+    assert_equal(expected, rendered_html)
+  end
+
+  describe 'without AUTOLINK_CLASS_NAME option' do
+    let(:options) { %i[DEFAULT] }
+    let(:expected) do
+      <<~HTML
+        <p><a href="https://example.com">https://example.com</a>
+        <a href="https://example.com">https://example.com</a>
+        <a href="https://example.com">Example</a>
+        <a href="mailto:test@example.com">test@example.com</a></p>
+      HTML
+    end
+
+    it "does not append class name to extension's autolink" do
+      assert_equal(expected, rendered_html)
+    end
+  end
+
+  describe 'without autolink extension' do
+    let(:extensions) { %i[] }
+    let(:expected) do
+      <<~HTML
+        <p>https://example.com
+        <a href="https://example.com">https://example.com</a>
+        <a href="https://example.com">Example</a>
+        test@example.com</p>
+      HTML
+    end
+
+    it 'does not append class name' do
+      assert_equal(expected, rendered_html)
+    end
+  end
+end


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the MIT License.
-->
## What

Add `AUTOLINK_CLASS_NAME` option for autolink extension.
Render autolinks with `class="autolink"` when `AUTOLINK_CLASS_NAME` option is enabled.

See the following test for an example.

https://github.com/increments/qiita_marker/blob/c7bc7f3c5db97da32292d19e39791aaf48bc336b/test/test_qfm_autolink_class_name.rb#L17-L24