### PR TITLE
Release v0.23.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+### Changed
+
+## 0.23.2.2 - 2022-01-11
+
+### Added
+
 - [#21](https://github.com/increments/qiita_marker/pull/21): Add `AUTOLINK_CLASS_NAME` option for autolink extension.
 
 ### Changed

--- a/lib/qiita_marker/version.rb
+++ b/lib/qiita_marker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QiitaMarker
-  VERSION = '0.23.2.1'
+  VERSION = '0.23.2.2'
 end


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the MIT License.
-->

### Added

- [#21](https://github.com/increments/qiita_marker/pull/21): Add `AUTOLINK_CLASS_NAME` option for autolink extension.

### Changed

- [#19](https://github.com/increments/qiita_marker/pull/19): Allow a custom block to contain any node type.
- [#20](https://github.com/increments/qiita_marker/pull/20): Allow `data-metadata` to accept strings up to the end of the line.
