### PR TITLE
Bump version to 0.23.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Changed
 
+## 0.23.5.0 - 2022-06-01
+
+### Changed
+
 - [#26](https://github.com/increments/qiita_marker/pull/26): Update base CommonMarker version to `v0.23.5`.
 
 ## 0.23.2.3 - 2022-03-04

--- a/lib/qiita_marker/version.rb
+++ b/lib/qiita_marker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QiitaMarker
-  VERSION = "0.23.2.3"
+  VERSION = "0.23.5.0"
 end


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the MIT License.
-->

### Changed

- [#26](https://github.com/increments/qiita_marker/pull/26): Update base CommonMarker version to `v0.23.5`.