### PR TITLE
Fix a bug that contains custom block fence in `data-metadata` when custom block is used in backquote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - [#28](https://github.com/increments/qiita_marker/pull/28): Fix a bug that sourcepos of custom_block is wrong.
+- [#30](https://github.com/increments/qiita_marker/pull/30): Fix a bug that contains custom block fence in `data-metadata` when custom block is used in backquote.
 
 ## 0.23.5.0 - 2022-06-01
 

--- a/ext/qiita_marker/qfm_custom_block.c
+++ b/ext/qiita_marker/qfm_custom_block.c
@@ -92,10 +92,11 @@ static cmark_node *try_opening_qfm_custom_block_block(
         1, sizeof(node_qfm_custom_block));
 
     cmark_strbuf *info = parser->mem->calloc(1, sizeof(cmark_strbuf));
+    bufsize_t info_startpos = cmark_parser_get_first_nonspace(parser) + matched;
 
     /* Length from after opening custom block fence to before newline character.
      */
-    bufsize_t info_len = len - matched;
+    bufsize_t info_len = len - info_startpos;
     if (info_len > 0 && input[len - 1] == '\n') {
       info_len -= 1;
     }
@@ -104,7 +105,7 @@ static cmark_node *try_opening_qfm_custom_block_block(
     }
 
     cmark_strbuf_init(parser->mem, info, info_len);
-    cmark_strbuf_put(info, input + matched, info_len);
+    cmark_strbuf_put(info, input + info_startpos, info_len);
     cmark_strbuf_trim(info);
     set_qfm_custom_block_info(custom_block_node, (char *)info->ptr);
 

--- a/test/test_qfm_custom_block.rb
+++ b/test/test_qfm_custom_block.rb
@@ -21,6 +21,10 @@ class TestQfmCustomBlock < Minitest::Test
       :::fizz buzz
       second custom block
       :::
+
+      > :::hoge fuga
+      > custom block in blockquote
+      > :::
     MD
     @doc = QiitaMarker.render_doc(text, [:UNSAFE], [:custom_block])
   end
@@ -40,6 +44,11 @@ class TestQfmCustomBlock < Minitest::Test
       <div data-type="customblock" data-metadata="fizz buzz">
       <p>second custom block</p>
       </div>
+      <blockquote>
+      <div data-type="customblock" data-metadata="hoge fuga">
+      <p>custom block in blockquote</p>
+      </div>
+      </blockquote>
     HTML
 
     assert_equal(@expected, @doc.to_html([:UNSAFE], [:custom_block]))
@@ -60,6 +69,11 @@ class TestQfmCustomBlock < Minitest::Test
       <div data-type="customblock" data-metadata="fizz buzz" data-sourcepos="14:1-16:3">
       <p data-sourcepos="15:1-15:19">second custom block</p>
       </div>
+      <blockquote data-sourcepos="18:1-20:5">
+      <div data-type="customblock" data-metadata="hoge fuga" data-sourcepos="18:3-20:5">
+      <p data-sourcepos="19:3-19:28">custom block in blockquote</p>
+      </div>
+      </blockquote>
     HTML
 
     assert_equal(@expected, @doc.to_html([:UNSAFE, :SOURCEPOS], [:custom_block]))


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the MIT License.
-->
## What

- Fix a bug that contains custom block fence in `data-metadata` when custom block is used in backquote.
    - https://github.com/increments/qiita_marker/issues/31