### PR TITLE
Bump version to 0.23.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Changed
 
+## 0.23.5.1 - 2022-06-21
+
+### Changed
+
 - [#28](https://github.com/increments/qiita_marker/pull/28): Fix a bug that sourcepos of custom_block is wrong.
 - [#30](https://github.com/increments/qiita_marker/pull/30): Fix a bug that contains custom block fence in `data-metadata` when custom block is used in backquote.
 

--- a/lib/qiita_marker/version.rb
+++ b/lib/qiita_marker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QiitaMarker
-  VERSION = "0.23.5.0"
+  VERSION = "0.23.5.1"
 end


### PR DESCRIPTION
### Changed

- [#28](https://github.com/increments/qiita_marker/pull/28): Fix a bug that sourcepos of custom_block is wrong.
- [#30](https://github.com/increments/qiita_marker/pull/30): Fix a bug that contains custom block fence in `data-metadata` when custom block is used in backquote.
