### PR TITLE
Release v0.23.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Changed
 
+## 0.23.6.0 - 2022-10-04
+
+### Changed
+
 - [#33](https://github.com/increments/qiita_marker/pull/33): Update base CommonMarker version to `v0.23.6`.
 
 ## 0.23.5.1 - 2022-06-21

--- a/lib/qiita_marker/version.rb
+++ b/lib/qiita_marker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QiitaMarker
-  VERSION = "0.23.5.1"
+  VERSION = "0.23.6.0"
 end


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the MIT License.
-->

### Changed

- [#33](https://github.com/increments/qiita_marker/pull/33): Update base CommonMarker version to `v0.23.6`.
