### PR TITLE
Drop ruby 2.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        ruby-version: [3.1, 3.0.0, 2.7.2, 2.6.6]
+        ruby-version: [3.1, 3.0.0, 2.7.2]
 
     runs-on: ${{ matrix.os }}
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ inherit_gem:
     - config/minitest.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
     - "ext/**/*"
     - "vendor/**/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- [#38](https://github.com/increments/qiita_marker/pull/38): Drop Ruby 2.6 support
+
 ## 0.23.6.1 - 2022-11-10
 
 - Finish testing phase and release official version.

--- a/lib/qiita_marker/node/inspect.rb
+++ b/lib/qiita_marker/node/inspect.rb
@@ -16,11 +16,11 @@ module QiitaMarker
         printer.group(PP_INDENT_SIZE, "#<#{self.class}(#{type}):", ">") do
           printer.breakable
 
-          attrs = [:sourcepos, :string_content, :url, :title, :header_level, :list_type, :list_start, :list_tight, :fence_info].map do |name|
+          attrs = [:sourcepos, :string_content, :url, :title, :header_level, :list_type, :list_start, :list_tight, :fence_info].filter_map do |name|
             [name, __send__(name)]
           rescue NodeError
             nil
-          end.compact
+          end
 
           printer.seplist(attrs) do |name, value|
             printer.text("#{name}=")

--- a/qiita_marker.gemspec
+++ b/qiita_marker.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.executables = ["qiita_marker"]
   s.require_paths = ["lib", "ext"]
-  s.required_ruby_version = [">= 2.6", "< 4.0"]
+  s.required_ruby_version = [">= 2.7", "< 4.0"]
 
   s.metadata["rubygems_mfa_required"] = "true"
 


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the MIT License.
-->
## What

- Drop ruby 2.6 support
    - ruby 2.6 is already EOL
- Fix rubocop offense Performance/MapCompact

## Reference

- https://www.ruby-lang.org/en/downloads/branches/
- https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancemapcompact