### PR TITLE
Release v0.23.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@
 
 ### Changed
 
-- Update base CommonMarker version to `v0.23.9`.
-- Drop Ruby 2.7 support
+## 0.23.9.0 - 2023-05-16
+
+### Changed
+
+- [#40](https://github.com/increments/qiita_marker/pull/40)
+  - Update base CommonMarker version to `v0.23.9`.
+  - Drop Ruby 2.7 support
 
 ## 0.23.6.2 - 2022-11-18
 

--- a/lib/qiita_marker/version.rb
+++ b/lib/qiita_marker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QiitaMarker
-  VERSION = "0.23.6.2"
+  VERSION = "0.23.9.0"
 end


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the MIT License.
-->

### Changed

- [#40](https://github.com/increments/qiita_marker/pull/40)
  - Update base CommonMarker version to `v0.23.9`.
  - Drop Ruby 2.7 support